### PR TITLE
grayscale to 2D array and float32 depth

### DIFF
--- a/opencv_mat.pxd
+++ b/opencv_mat.pxd
@@ -6,6 +6,8 @@ cdef extern from "core/core.hpp":
   cdef int  CV_WINDOW_AUTOSIZE
   cdef int CV_8UC3
   cdef int CV_8UC1
+  cdef int CV_8U
+  cdef int CV_32F
 
 cdef extern from "core/core.hpp" namespace "cv":
   cdef cppclass Mat:
@@ -15,6 +17,8 @@ cdef extern from "core/core.hpp" namespace "cv":
     int rows
     int cols
     int channels()
+    int depth()
+    size_t elemSize()
 
 # For Buffer usage
 cdef extern from "Python.h":


### PR DESCRIPTION
- grayscale Mat are transformed in 2D numpy array and vice-versa (previously 3D), ready to be used in pyplot.imshow()

- Mat2np() accepts now images of deph float32 